### PR TITLE
Redirect / to /docs/index.html in production

### DIFF
--- a/apps/keck/src/server/mod.rs
+++ b/apps/keck/src/server/mod.rs
@@ -5,6 +5,7 @@ mod storage;
 mod utils;
 
 use axum::{
+    response::Redirect,
     routing::{delete, get, head, post},
     Extension, Router, Server,
 };
@@ -66,9 +67,18 @@ pub async fn start_server() {
 
     let context = Arc::new(Context::new(None, None).await);
 
-    let app = collaboration::collaboration_handler(api::api_handler(Router::new()))
+    let mut app = collaboration::collaboration_handler(api::api_handler(Router::new()))
         .layer(cors)
-        .layer(Extension(context.clone()))
+        .layer(Extension(context.clone()));
+
+    if !cfg!(debug_assertions) {
+        // Redirect to docs in production until we have a proper home page
+        // FIXME: Notice that you can't test this locally because the debug_assertions are used to determine where the built file are too
+        // So, after this redirects you locally, it will still be 404, since the files will be expected at a production path like `/app/book`.
+        app = app.route("/", get(|| async { Redirect::to("/docs/index.html") }));
+    }
+
+    app = app
         .nest_service("/docs", get(files::docs_handler))
         .fallback_service(get(files::index_handler));
 


### PR DESCRIPTION
Fixes 404 on root of domain
<img width="1257" alt="Cole's screen capture of crdts cloud  2022-12-15 at 14 08 52@2x" src="https://user-images.githubusercontent.com/2925395/207946430-4a85a81c-048a-4064-b636-b1fffe43e80e.png">
