### PR TITLE
dev: Add 404 page for finding Keck services & diagnosing issues

### DIFF
--- a/apps/keck/src/server/404-dev.html
+++ b/apps/keck/src/server/404-dev.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>OctoBase Keck</title>
+    <style>
+      body {
+        margin: 0 auto;
+        padding: 2rem;
+        max-width: 34rem;
+        font-family: system-ui, -apple-system, Arial, sans-serif;
+      }
+      a {
+        text-decoration: none;
+      }
+      a:hover {
+        text-decoration: underline;
+      }
+      a,
+      a:visited {
+        color: dodgerblue;
+      }
+      code {
+        background-color: bisque;
+        padding: 0.1em 0.2em;
+        margin: -0.1em -0.2em;
+      }
+      .error-banner {
+        background-color: rgb(255, 245, 231);
+        padding: 1rem;
+      }
+      .error-banner:empty {
+        display: none;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>OctoBase Keck</h1>
+    <div class="error-banner">{{ERROR_BANNER}}</div>
+    <h3>Directory</h3>
+    <ul>
+      <li><a href="/index.html">Undo & Redo block test page /index.html</a></li>
+      <li><a href="/api/docs/">Swagger UI (Open API 3 UI)</a></li>
+      <li><a href="/docs/index.html">Handbook of OctoBase Docs</a></li>
+    </ul>
+  </body>
+</html>

--- a/apps/keck/src/server/404.html
+++ b/apps/keck/src/server/404.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Not found in OctoBase</title>
+    <style>
+      body {
+        margin: 0 auto;
+        padding: 2rem;
+        max-width: 34rem;
+        font-family: system-ui, -apple-system, Arial, sans-serif;
+      }
+      a {
+        text-decoration: none;
+      }
+      a:hover {
+        text-decoration: underline;
+      }
+      a,
+      a:visited {
+        color: dodgerblue;
+      }
+      code {
+        background-color: bisque;
+        padding: 0.1em 0.2em;
+        margin: -0.1em -0.2em;
+      }
+      .error-banner {
+        background-color: rgb(255, 245, 231);
+        padding: 1rem;
+      }
+      .error-banner:empty {
+        display: none;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Not found in OctoBase</h1>
+    <!-- {{ERROR_BANNER}} -->
+    <h3>Directory</h3>
+    <ul>
+      <li><a href="/docs/index.html">Handbook of OctoBase Docs</a></li>
+    </ul>
+  </body>
+</html>

--- a/apps/keck/src/server/files.rs
+++ b/apps/keck/src/server/files.rs
@@ -18,28 +18,92 @@ const DOCS_DIST_PATH: &str = if cfg!(debug_assertions) {
     "/app/book"
 };
 
+static GENERAL_INDEX_FILES_ERROR: &'static str = if cfg!(debug_assertions) {
+    r#"If you aren't already, make sure you are using <code>cargo run --package=keck</code> from the workspace root."#
+} else {
+    ""
+};
+
 pub async fn index_handler(uri: Uri) -> Result<Response<BoxBody>, (StatusCode, String)> {
     info!("get {:?}", uri);
+
+    if let "/" | "" = uri.path() {
+        return Ok(create_homepage());
+    }
+
     let res = get_static_file(uri.clone(), INDEX_DIST_PATH.to_owned()).await?;
 
-    if res.status() == StatusCode::NOT_FOUND {
-        get_static_file(Uri::from_static("/index.html"), INDEX_DIST_PATH.to_owned()).await
-    } else {
-        Ok(res)
+    if res.status() != StatusCode::NOT_FOUND {
+        // asset file found
+        return Ok(res);
     }
+
+    if let "/index.html" = uri.path() {
+        let index_result =
+            get_static_file(Uri::from_static("/index.html"), INDEX_DIST_PATH.to_owned()).await?;
+        if res.status() == StatusCode::NOT_FOUND {
+            // index file not found...
+            return Ok(create_404(format!("Failed to find built index for <code>{INDEX_DIST_PATH}/index.html</code>. Make sure you've run <code>pnpm install && pnpm build</code> in <code>apps/frontend</code> to access this page. {GENERAL_INDEX_FILES_ERROR}")));
+        }
+
+        return Ok(index_result);
+    }
+
+    Ok(create_404(format!(
+        "Failed to find index file or asset (<code>.{uri}</code>) at <code>{INDEX_DIST_PATH}</code>. {GENERAL_INDEX_FILES_ERROR}"
+    )))
 }
 
 pub async fn docs_handler(uri: Uri) -> Result<Response<BoxBody>, (StatusCode, String)> {
     info!("get {:?}", uri);
     let res = get_static_file(uri.clone(), DOCS_DIST_PATH.to_owned()).await?;
 
-    if res.status() == StatusCode::NOT_FOUND {
-        get_static_file(Uri::from_static("/index.html"), DOCS_DIST_PATH.to_owned()).await
-    } else {
-        Ok(res)
+    if res.status() != StatusCode::NOT_FOUND {
+        // asset file found
+        return Ok(res);
     }
+
+    if let "/index.html" = uri.path() {
+        let found_index =
+            get_static_file(Uri::from_static("/index.html"), DOCS_DIST_PATH.to_owned()).await?;
+        if found_index.status() == StatusCode::NOT_FOUND {
+            return Ok(create_404(format!(
+                "Couldn't find main index file for docs. {GENERAL_INDEX_FILES_ERROR}"
+            )));
+        }
+
+        return Ok(found_index);
+    }
+
+    Ok(create_404(format!(
+        "Failed to find index file or asset (<code>.{uri}</code>) in <code>{DOCS_DIST_PATH}</code>. {GENERAL_INDEX_FILES_ERROR}"
+    )))
 }
 
+#[cfg(debug_assertions)]
+static PAGE_404: &str = include_str!("./404-dev.html");
+#[cfg(not(debug_assertions))]
+static PAGE_404: &str = include_str!("./404.html");
+
+fn create_404(message: impl AsRef<str>) -> Response<BoxBody> {
+    Response::builder()
+        .header("Content-Type", "text/html")
+        .status(404)
+        .body(boxed(
+            PAGE_404.replace("{{ERROR_BANNER}}", message.as_ref()),
+        ))
+        .unwrap()
+}
+
+fn create_homepage() -> Response<BoxBody> {
+    Response::builder()
+        .header("Content-Type", "text/html")
+        .status(200)
+        .body(boxed(PAGE_404.replace("{{ERROR_BANNER}}", "")))
+        .unwrap()
+}
+
+// Reference from https://benw.is/posts/serving-static-files-with-axum
 async fn get_static_file(
     uri: Uri,
     dist: String,


### PR DESCRIPTION
Before & after in development
![Cole's screen capture of Keck JWST  2022-12-15 at 13 39 44@2x](https://user-images.githubusercontent.com/2925395/208006645-247d4b47-f32b-48ce-8904-bda6e1b66640.png)

In production:
<img width="1121" alt="Cole's screen capture of Not found in OctoBase 2022-12-15 at 20 56 47@2x" src="https://user-images.githubusercontent.com/2925395/208004318-bf46222a-5e66-400c-9e05-4e8f4e1fb62a.png">

In development:

https://user-images.githubusercontent.com/2925395/208006691-cce7d52e-73a1-4b85-8f07-aa3adf73e4ab.mp4


**As a final change made after the recordings, in development, I made the heading "OctoBase Keck"**