### PR TITLE
Fix Open API definitions for Workspace Search

### DIFF
--- a/apps/keck/src/server/api/blocks/mod.rs
+++ b/apps/keck/src/server/api/blocks/mod.rs
@@ -39,7 +39,7 @@ use utoipa::OpenApi;
             schema::InsertChildren,
             schema::Workspace, schema::Block, schema::BlockRawHistory,
             jwst::BlockHistory, jwst::HistoryOperation, jwst::RawHistory,
-            jwst::SearchResults
+            jwst::SearchResults, jwst::SearchResult
         )
     ),
     tags(

--- a/libs/jwst/src/lib.rs
+++ b/libs/jwst/src/lib.rs
@@ -11,4 +11,6 @@ pub use history::{
 pub use log::{error, info};
 pub use storage::{BlobMetadata, BlobStorage, DocStorage};
 pub use utils::encode_update;
-pub use workspace::{SearchResults, Workspace, WorkspaceTransaction};
+#[cfg(feature = "workspace-search")]
+pub use workspace::{SearchResult, SearchResults};
+pub use workspace::{Workspace, WorkspaceTransaction};

--- a/libs/jwst/src/workspace/mod.rs
+++ b/libs/jwst/src/workspace/mod.rs
@@ -8,5 +8,5 @@ use plugins::PluginMap;
 pub(crate) use content::Content;
 
 #[cfg(feature = "workspace-search")]
-pub use plugins::SearchResults;
+pub use plugins::{SearchResult, SearchResults};
 pub use workspace::{Workspace, WorkspaceTransaction};

--- a/libs/jwst/src/workspace/plugins/indexing/mod.rs
+++ b/libs/jwst/src/workspace/plugins/indexing/mod.rs
@@ -5,5 +5,5 @@ mod tokenizer;
 use super::{Content, PluginImpl, PluginRegister, Workspace};
 use tokenizer::{tokenizers_register, LANG_CN};
 
-pub use indexing::{IndexingPluginImpl, SearchResults};
+pub use indexing::{IndexingPluginImpl, SearchResult, SearchResults};
 pub(super) use register::IndexingPluginRegister;

--- a/libs/jwst/src/workspace/plugins/mod.rs
+++ b/libs/jwst/src/workspace/plugins/mod.rs
@@ -9,7 +9,7 @@ pub(super) use indexing::IndexingPluginImpl;
 pub(super) use plugins::{PluginImpl, PluginMap, PluginRegister};
 
 #[cfg(feature = "workspace-search")]
-pub use indexing::SearchResults;
+pub use indexing::{SearchResult, SearchResults};
 
 /// Setup a [WorkspacePlugin] and insert it into the [Workspace].
 /// See [plugins].


### PR DESCRIPTION
<img width="905" alt="Cole's screen capture of Swagger UI 2022-12-22 at 00 10 29@2x" src="https://user-images.githubusercontent.com/2925395/209071474-e381024e-9d7d-4e10-97a0-14bca08f4fc6.png">

Before, this was empty