### PR TITLE
Add compilation error message for enabling both sqlite & mysql

### DIFF
--- a/libs/jwst-storage/src/docs/mod.rs
+++ b/libs/jwst-storage/src/docs/mod.rs
@@ -1,5 +1,11 @@
 mod entities;
 mod filesystem;
+
+#[cfg(all(feature = "sqlite", feature = "mysql"))]
+compile_error!(
+    "Both features \"sqlite\" and \"mysql\" may not be enabled at the same time for this crate."
+);
+
 #[cfg(feature = "mysql")]
 mod mysql;
 mod orm;


### PR DESCRIPTION
I'm not sure what the fix is, but the first thing we can do is add a more informative message.