### PR TITLE
fix: doc cannot be generated

### DIFF
--- a/apps/cloud/src/api/mod.rs
+++ b/apps/cloud/src/api/mod.rs
@@ -322,7 +322,9 @@ async fn get_workspace_doc(ctx: Arc<Context>, workspace_id: String) -> Response 
         .into_response()
 }
 
-/// Resolves to [WorkspaceSearchResults]
+/// Resolves to [`SearchResults`]
+///
+/// [`SearchResults`]: jwst::SearchResults
 async fn search_workspace(
     Extension(ctx): Extension<Arc<Context>>,
     Extension(claims): Extension<Arc<Claims>>,

--- a/libs/cloud-database/src/orm/database.rs
+++ b/libs/cloud-database/src/orm/database.rs
@@ -109,7 +109,7 @@ impl CloudDatabase {
         &self,
         user: CreateUser,
     ) -> Result<Option<(UsersModel, WorkspacesModel)>, DbErr> {
-        let mut trx = self.pool.begin().await?;
+        let trx = self.pool.begin().await?;
 
         let uuid = Uuid::new_v4().to_string();
         let Ok(user) = Users::insert(UsersActiveModel {

--- a/libs/jwst-binding/jwst-jni/Cargo.toml
+++ b/libs/jwst-binding/jwst-jni/Cargo.toml
@@ -27,3 +27,4 @@ rifgen = "^0.1.61"
 [lib]
 name = "jwst"
 crate-type = ["cdylib"]
+doc = false

--- a/libs/jwst/src/workspaces/plugins/indexing/indexing.rs
+++ b/libs/jwst/src/workspaces/plugins/indexing/indexing.rs
@@ -13,7 +13,9 @@ pub struct SearchResult {
     pub score: f32,
 }
 
-/// Returned from [Workspace::search]
+/// Returned from [`Workspace::search`]
+///
+/// [`Workspace::search`]: crate::Workspace::search
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct SearchResults(Vec<SearchResult>);
 


### PR DESCRIPTION
It can be added to the CI.

```
RUSTDOCFLAGS="-D rustdoc::broken-intra-doc-links" cargo doc --workspace --all-features --no-deps
```

