### PR TITLE
Remove `#[swift_bridge(associated_to = ...)]`

### DIFF
--- a/libs/jwst-binding/jwst-swift/src/lib.rs
+++ b/libs/jwst-binding/jwst-swift/src/lib.rs
@@ -11,89 +11,62 @@ mod ffi {
     extern "Rust" {
         type Block;
 
-        #[swift_bridge(associated_to = Block)]
         fn get(self: &Block, block_id: String) -> Option<DynamicValue>;
 
-        #[swift_bridge(associated_to = Block)]
         pub fn children(self: &Block) -> Vec<String>;
 
-        #[swift_bridge(associated_to = Block)]
         pub fn push_children(self: &Block, block: &Block);
 
-        #[swift_bridge(associated_to = Block)]
         pub fn insert_children_at(&self, block: &Block, pos: u32);
 
-        #[swift_bridge(associated_to = Block)]
         pub fn insert_children_before(
             self: &Block,
             block: &Block,
             reference: &str,
         );
 
-        #[swift_bridge(associated_to = Block)]
         pub fn insert_children_after(self: &Block, block: &Block, reference: &str);
 
-        #[swift_bridge(associated_to = Block)]
         pub fn remove_children(self: &Block, block: &Block);
 
-        #[swift_bridge(associated_to = Block)]
         pub fn exists_children(self: &Block, block_id: &str) -> i32;
 
-        #[swift_bridge(associated_to = Block)]
         pub fn parent(self: &Block) -> String;
 
-        #[swift_bridge(associated_to = Block)]
         pub fn updated(self: &Block) -> u64;
 
-        #[swift_bridge(associated_to = Block)]
         pub fn id(self: &Block) -> String;
 
-        #[swift_bridge(associated_to = Block)]
         pub fn flavor(self: &Block) -> String;
 
-        #[swift_bridge(associated_to = Block)]
         pub fn version(self: &Block) -> String;
 
-        #[swift_bridge(associated_to = Block)]
         pub fn created(self: &Block) -> u64;
 
-        #[swift_bridge(associated_to = Block)]
         pub fn set_bool(self: &Block, key: String, value: bool);
 
-        #[swift_bridge(associated_to = Block)]
         pub fn set_string(self: &Block, key: String, value: String);
 
-        #[swift_bridge(associated_to = Block)]
         pub fn set_float(self: &Block, key: String, value: f64);
 
-        #[swift_bridge(associated_to = Block)]
         pub fn set_integer(self: &Block, key: String, value: i64);
 
-        #[swift_bridge(associated_to = Block)]
         pub fn set_null(self: &Block, key: String);
 
-        #[swift_bridge(associated_to = Block)]
         pub fn is_bool(self: &Block, key: String) -> bool;
 
-        #[swift_bridge(associated_to = Block)]
         pub fn is_string(self: &Block, key: String) -> bool;
 
-        #[swift_bridge(associated_to = Block)]
         pub fn is_float(&self, key: String) -> bool;
 
-        #[swift_bridge(associated_to = Block)]
         pub fn is_integer(&self, key: String) -> bool;
 
-        #[swift_bridge(associated_to = Block)]
         pub fn get_bool(&self, key: String) -> Option<i64>;
 
-        #[swift_bridge(associated_to = Block)]
         pub fn get_string(&self, key: String) -> Option<String>;
 
-        #[swift_bridge(associated_to = Block)]
         pub fn get_float(&self, key: String) -> Option<f64>;
 
-        #[swift_bridge(associated_to = Block)]
         pub fn get_integer(&self, key: String) -> Option<i64>;
     }
 
@@ -101,25 +74,18 @@ mod ffi {
         type DynamicValue;
         type DynamicValueMap;
 
-        #[swift_bridge(associated_to = DynamicValue)]
         fn as_bool(self: &DynamicValue) -> Option<bool>;
 
-        #[swift_bridge(associated_to = DynamicValue)]
         fn as_number(self: &DynamicValue) -> Option<f64>;
 
-        #[swift_bridge(associated_to = DynamicValue)]
         fn as_int(self: &DynamicValue) -> Option<i64>;
 
-        #[swift_bridge(associated_to = DynamicValue)]
         fn as_string(self: &DynamicValue) -> Option<String>;
 
-        #[swift_bridge(associated_to = DynamicValue)]
         fn as_map(self: &DynamicValue) -> Option<DynamicValueMap>;
 
-        #[swift_bridge(associated_to = DynamicValue)]
         fn as_array(self: &DynamicValue) -> Option<Vec<DynamicValue>>;
 
-        #[swift_bridge(associated_to = DynamicValue)]
         fn as_buffer(self: &DynamicValue) -> Option<Vec<u8>>;
     }
 
@@ -129,15 +95,12 @@ mod ffi {
         #[swift_bridge(init)]
         fn new(id: String) -> Workspace;
 
-        #[swift_bridge(associated_to = Workspace)]
         fn id(self: &Workspace) -> String;
 
         fn client_id(self: &Workspace) -> u64;
 
-        #[swift_bridge(associated_to = Workspace)]
         fn get(self: &Workspace, block_id: String) -> Option<Block>;
 
-        #[swift_bridge(associated_to = Workspace)]
         fn create(self: &Workspace, block_id: String, flavor: String) -> Block;
     }
 }


### PR DESCRIPTION
This commit removes the `#[swift_bridge(associated_to = ...)]` from the methods on the `Block`, `DynamicValue` and `Workspace` types.

The `associated_to` attribute is meant to be used for static methods. It does nothing on instance methods.

In the future, `swift-bridge` will turn this into a compile time error https://github.com/chinedufn/swift-bridge/issues/179 .