### PR TITLE
feat: provide method to skip remote sync

### DIFF
--- a/apps/swift/OctoBaseSwift/RustXcframework.xcframework/Info.plist
+++ b/apps/swift/OctoBaseSwift/RustXcframework.xcframework/Info.plist
@@ -22,6 +22,20 @@
 			<key>HeadersPath</key>
 			<string>Headers</string>
 			<key>LibraryIdentifier</key>
+			<string>ios-arm64</string>
+			<key>LibraryPath</key>
+			<string>liboctobase.a</string>
+			<key>SupportedArchitectures</key>
+			<array>
+				<string>arm64</string>
+			</array>
+			<key>SupportedPlatform</key>
+			<string>ios</string>
+		</dict>
+		<dict>
+			<key>HeadersPath</key>
+			<string>Headers</string>
+			<key>LibraryIdentifier</key>
 			<string>ios-arm64-simulator</string>
 			<key>LibraryPath</key>
 			<string>liboctobase.a</string>
@@ -33,20 +47,6 @@
 			<string>ios</string>
 			<key>SupportedPlatformVariant</key>
 			<string>simulator</string>
-		</dict>
-		<dict>
-			<key>HeadersPath</key>
-			<string>Headers</string>
-			<key>LibraryIdentifier</key>
-			<string>ios-arm64</string>
-			<key>LibraryPath</key>
-			<string>liboctobase.a</string>
-			<key>SupportedArchitectures</key>
-			<array>
-				<string>arm64</string>
-			</array>
-			<key>SupportedPlatform</key>
-			<string>ios</string>
 		</dict>
 	</array>
 	<key>CFBundlePackageType</key>

--- a/apps/swift/OctoBaseSwift/RustXcframework.xcframework/ios-arm64-simulator/Headers/SwiftBridgeCore.h
+++ b/apps/swift/OctoBaseSwift/RustXcframework.xcframework/ios-arm64-simulator/Headers/SwiftBridgeCore.h
@@ -143,3 +143,6 @@ void __swift_bridge__$free_boxed_fn_once_no_args_no_return(void* boxed_fnonce);
 
 
 struct __private__ResultPtrAndPtr { bool is_ok; void* ok_or_err; };
+
+
+struct __private__ResultVoidAndPtr { bool is_ok; void* err; };

--- a/apps/swift/OctoBaseSwift/RustXcframework.xcframework/ios-arm64/Headers/SwiftBridgeCore.h
+++ b/apps/swift/OctoBaseSwift/RustXcframework.xcframework/ios-arm64/Headers/SwiftBridgeCore.h
@@ -143,3 +143,6 @@ void __swift_bridge__$free_boxed_fn_once_no_args_no_return(void* boxed_fnonce);
 
 
 struct __private__ResultPtrAndPtr { bool is_ok; void* ok_or_err; };
+
+
+struct __private__ResultVoidAndPtr { bool is_ok; void* err; };

--- a/apps/swift/OctoBaseSwift/RustXcframework.xcframework/macos-arm64/Headers/SwiftBridgeCore.h
+++ b/apps/swift/OctoBaseSwift/RustXcframework.xcframework/macos-arm64/Headers/SwiftBridgeCore.h
@@ -143,3 +143,6 @@ void __swift_bridge__$free_boxed_fn_once_no_args_no_return(void* boxed_fnonce);
 
 
 struct __private__ResultPtrAndPtr { bool is_ok; void* ok_or_err; };
+
+
+struct __private__ResultVoidAndPtr { bool is_ok; void* err; };

--- a/apps/swift/OctoBaseSwift/Sources/OctoBase/jwst-swift.swift
+++ b/apps/swift/OctoBaseSwift/Sources/OctoBase/jwst-swift.swift
@@ -407,7 +407,7 @@ extension WorkspaceRef {
     public func search<GenericIntoRustString: IntoRustString>(_ query: GenericIntoRustString) -> RustString {
         RustString(ptr: __swift_bridge__$Workspace$search(ptr, { let rustString = query.intoRustString(); rustString.isOwned = false; return rustString.ptr }()))
     }
-    
+
     public func get_blocks_by_flavour<GenericToRustStr: ToRustStr>(_ flavour: GenericToRustStr) -> RustVec<Block> {
         return flavour.toRustStr({ flavourAsRustStr in
             RustVec(ptr: __swift_bridge__$Workspace$get_blocks_by_flavour(ptr, flavourAsRustStr))

--- a/libs/jwst-rpc/src/client.rs
+++ b/libs/jwst-rpc/src/client.rs
@@ -149,7 +149,7 @@ fn start_sync_thread(workspace: &Workspace, remote: String, mut rx: Receiver<Vec
                     remote.clone(),
                     &mut rx,
                 )
-                .await
+                    .await
                 {
                     Ok(true) => {
                         debug!("sync thread finished");
@@ -187,12 +187,14 @@ pub async fn start_client(
 ) -> JwstResult<Workspace> {
     let workspace = storage.docs().get(id.clone()).await?;
 
-    if let Entry::Vacant(entry) = storage.docs().remote().write().await.entry(id.clone()) {
-        let (tx, rx) = channel(100);
+    if !remote.is_empty() {
+        if let Entry::Vacant(entry) = storage.docs().remote().write().await.entry(id.clone()) {
+            let (tx, rx) = channel(100);
 
-        start_sync_thread(&workspace, remote, rx);
+            start_sync_thread(&workspace, remote, rx);
 
-        entry.insert(tx);
+            entry.insert(tx);
+        }
     }
 
     Ok(workspace)

--- a/libs/jwst-rpc/src/client.rs
+++ b/libs/jwst-rpc/src/client.rs
@@ -149,7 +149,7 @@ fn start_sync_thread(workspace: &Workspace, remote: String, mut rx: Receiver<Vec
                     remote.clone(),
                     &mut rx,
                 )
-                    .await
+                .await
                 {
                     Ok(true) => {
                         debug!("sync thread finished");


### PR DESCRIPTION
How about using `String.isEmpty()` in replace of `Option::Some(T)` to avoid breaking change in android binding