### PR TITLE
feat: add timeout when starting sync thread

### DIFF
--- a/libs/jwst-rpc/src/client.rs
+++ b/libs/jwst-rpc/src/client.rs
@@ -135,16 +135,17 @@ async fn run_sync(
 fn start_sync_thread(workspace: &Workspace, remote: String, mut rx: Receiver<Vec<u8>>) {
     debug!("spawn sync thread");
     let first_sync = Arc::new(AtomicBool::new(false));
-    let [first_sync_cloned, first_sync_cloned2] = [first_sync.clone(), first_sync.clone()];
+    let first_sync_cloned = first_sync.clone();
     let workspace = workspace.clone();
     std::thread::spawn(move || {
         let Ok(rt) = tokio::runtime::Runtime::new() else {
             return error!("Failed to create runtime");
         };
         rt.block_on(async move {
+            let first_sync_cloned_2 = first_sync_cloned.clone();
             tokio::spawn(async move {
                 sleep(Duration::from_secs(2)).await;
-                first_sync_cloned2.store(true, Ordering::Release);
+                first_sync_cloned_2.store(true, Ordering::Release);
             });
             loop {
                 match run_sync(


### PR DESCRIPTION
close https://github.com/toeverything/OctoBase/issues/250

This PR allows early [return of workspace](https://github.com/toeverything/OctoBase/blob/bad2e26543852f4ed3823316ddcda9819b847c3f/libs/jwst-binding/jwst-swift/src/storage.rs#L49) when `sync_thread` is not ready after 2s due to kinds of network delay. And it keeps previous collaboration behavior, ie, when `sync_thread` is ready afterward, the synchronization between multiple clients can start based on the state at the time when `sync_thread` is ready.