### PR TITLE
Some minor cleanup

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,9 @@
 [env]
 CARGO_WORKSPACE_DIR = { value = "", relative = true }
 
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-C", "target-cpu=native"]
+
 [target.aarch64-linux-android]
 runner = "./apps/android/run-on-android.sh"
 

--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -10,64 +10,65 @@
 name: Clippy analyze & Doc check
 
 on:
-    push:
-        branches: ['master']
-    pull_request:
-        # The branches below must be a subset of the branches above
-        branches: ['master']
-    schedule:
-        - cron: '0 4 * * 5'
+  push:
+    branches: ['master']
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: ['master']
+  schedule:
+    - cron: '0 4 * * 5'
 
 jobs:
-    rust-clippy-analyze:
-        name: Run rust-clippy analyzing
-        runs-on: ubuntu-latest
-        permissions:
-            contents: read
-            security-events: write
-            actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@v2
-              with:
-                  submodules: true
-                  fetch-depth: 0
+  rust-clippy-analyze:
+    name: Run rust-clippy analyzing
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+          fetch-depth: 0
 
-            - name: Install Rust toolchain
-              uses: actions-rs/toolchain@v1
-              with:
-                  profile: minimal
-                  toolchain: stable
-                  components: clippy
-                  override: true
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          components: clippy
+          override: true
 
-            - name: Set up cargo cache
-              uses: actions/cache@v3
-              continue-on-error: false
-              with:
-                  path: |
-                      ~/.cargo/bin/
-                      ~/.cargo/registry/index/
-                      ~/.cargo/registry/cache/
-                      ~/.cargo/git/db/
-                      ./vendor
-                      ./.cargo/config
-                  key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-                  restore-keys: ${{ runner.os }}-cargo-
+      - name: Set up cargo cache
+        uses: actions/cache@v3
+        continue-on-error: false
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            ./vendor
+            ./.cargo/config
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
 
-            - name: Cargo Vendor
-              run: cargo vendor > .cargo/config
+      - name: Cargo Vendor
+        run: cargo vendor > .cargo/config
 
-            - name: Install required cargo
-              run: cargo install clippy-sarif sarif-fmt --force
+      - name: Install required cargo
+        run: cargo install clippy-sarif sarif-fmt --force
 
-            - name: Run rust-clippy & doc generate
-              run: cargo clippy --all-features --message-format=json | clippy-sarif | tee rust-clippy-results.sarif | sarif-fmt
-                  RUSTDOCFLAGS="-D rustdoc::broken-intra-doc-links" cargo doc --workspace --all-features --no-deps
-              continue-on-error: true
+      - name: Run rust-clippy & doc generate
+        run:
+          cargo clippy --all-features --message-format=json | clippy-sarif | tee rust-clippy-results.sarif | sarif-fmt
+          RUSTDOCFLAGS="-D rustdoc::broken-intra-doc-links" cargo doc --workspace --all-features --no-deps
+        continue-on-error: true
 
-            - name: Upload analysis results to GitHub
-              uses: github/codeql-action/upload-sarif@v1
-              with:
-                  sarif_file: rust-clippy-results.sarif
-                  wait-for-processing: true
+      - name: Upload analysis results to GitHub
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: rust-clippy-results.sarif
+          wait-for-processing: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,6 +86,7 @@ dependencies = [
  "jwst-storage",
  "lettre",
  "lib0",
+ "mimalloc",
  "mime",
  "moka",
  "pem",
@@ -2089,6 +2090,7 @@ dependencies = [
  "lib0",
  "log",
  "mdbook",
+ "mimalloc",
  "serde",
  "serde_json",
  "sqlx",
@@ -2186,6 +2188,16 @@ name = "libm"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
+
+[[package]]
+name = "libmimalloc-sys"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd8c7cbf8b89019683667e347572e6d55a7df7ea36b0c4ce69961b0cde67b174"
+dependencies = [
+ "cc",
+ "libc",
+]
 
 [[package]]
 name = "libsqlite3-sys"
@@ -2367,6 +2379,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dcb174b18635f7561a0c6c9fc2ce57218ac7523cf72c50af80e2d79ab8f3ba1"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 
 [profile.release]
 lto = true
-opt-level = "z"
+opt-level = 3
 codegen-units = 1
 
 [profile.dev.package.sqlx-macros]

--- a/apps/cloud/Cargo.toml
+++ b/apps/cloud/Cargo.toml
@@ -31,6 +31,7 @@ lettre = { version = "0.10.2", default-features = false, features = [
 ] }
 lib0 = "0.16.2"
 mime = "0.3.16"
+mimalloc = "0.1"
 moka = { version = "0.9.6", features = ["future"] }
 pem = "1.1.0"
 rand = "0.8.5"

--- a/apps/cloud/src/api/blobs.rs
+++ b/apps/cloud/src/api/blobs.rs
@@ -235,7 +235,7 @@ pub async fn upload_blob_in_workspace(
 pub async fn create_workspace(
     Extension(ctx): Extension<Arc<Context>>,
     Extension(claims): Extension<Arc<Claims>>,
-    TypedHeader(length): TypedHeader<ContentLength>,
+    TypedHeader(_length): TypedHeader<ContentLength>,
     stream: BodyStream,
 ) -> Response {
     match ctx.db.create_normal_workspace(claims.user.id.clone()).await {

--- a/apps/cloud/src/context.rs
+++ b/apps/cloud/src/context.rs
@@ -182,6 +182,7 @@ impl Context {
         encode(&Header::default(), user, &self.key.jwt_encode).expect("encode JWT error")
     }
 
+    #[allow(unused)]
     pub fn decode_jwt(&self, token: &str) -> Option<Claims> {
         use jsonwebtoken::{decode, Validation};
         if let Ok(res) = decode::<Claims>(token, &self.key.jwt_decode, &Validation::default()) {

--- a/apps/cloud/src/main.rs
+++ b/apps/cloud/src/main.rs
@@ -11,6 +11,9 @@ mod files;
 mod layer;
 mod utils;
 
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 #[tokio::main]
 async fn main() {
     init_logger();

--- a/apps/keck/Cargo.toml
+++ b/apps/keck/Cargo.toml
@@ -32,6 +32,7 @@ log = { version = "0.4.17", features = [
   "release_max_level_info",
 ] }
 dotenvy = "0.15.6"
+mimalloc = "0.1"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.93"
 sqlx = { version = "0.6.2", features = [
@@ -51,7 +52,7 @@ tokio = { version = "1.25.0", features = [
 ] }
 utoipa = { version = "2.4.2", features = ["axum_extras"], optional = true }
 utoipa-swagger-ui = { version = "3.0.2", features = ["axum"], optional = true }
-uuid = { version = "1.3.0", default-features = false, features = ["v4"] }
+uuid = { version = "1.3.0", default-features = false, features = ["v4", "fast-rng"] }
 yrs = "0.16.2"
 
 # ======= workspace dependencies =======

--- a/apps/keck/src/main.rs
+++ b/apps/keck/src/main.rs
@@ -2,6 +2,9 @@ mod server;
 
 use jwst_logger::init_logger;
 
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 #[tokio::main]
 async fn main() {
     init_logger();

--- a/libs/cloud-database/src/database.rs
+++ b/libs/cloud-database/src/database.rs
@@ -721,8 +721,8 @@ mod test {
             .unwrap()
             .unwrap();
         assert_eq!(workspace_owner.id, new_user.id);
-        assert_eq!(new_workspace.public, false);
-        assert_eq!(is_published, false);
+        assert!(!new_workspace.public);
+        assert!(!is_published);
         new_workspace = pool
             .update_workspace(new_workspace.id.clone(), UpdateWorkspace { public: true })
             .await
@@ -732,8 +732,8 @@ mod test {
             .is_public_workspace(new_workspace.id.clone())
             .await
             .unwrap();
-        assert_eq!(new_workspace.public, true);
-        assert_eq!(is_published, true);
+        assert!(new_workspace.public);
+        assert!(is_published);
 
         Ok(())
     }
@@ -838,15 +838,12 @@ mod test {
             new_workspace.id.clone()
         );
         assert_eq!(accept_permission.r#type.clone(), PermissionType::Admin);
+        assert_eq!(accept_permission.user_id.unwrap(), new_user2.id.clone());
         assert_eq!(
-            accept_permission.user_id.unwrap().clone(),
-            new_user2.id.clone()
-        );
-        assert_eq!(
-            accept_permission.user_email.unwrap().clone(),
+            accept_permission.user_email.unwrap(),
             new_user2.email.clone()
         );
-        assert_eq!(accept_permission.accepted, true);
+        assert!(accept_permission.accepted);
 
         let workspace_owner = pool
             .get_workspace_owner(new_workspace.id.clone())
@@ -921,9 +918,9 @@ mod test {
             .get_user_in_workspace_by_email(new_workspace.id.clone(), &new_user3.email.clone())
             .await
             .unwrap();
-        assert_eq!(user1_in_workspace.in_workspace, true);
-        assert_eq!(user2_in_workspace.in_workspace, true);
-        assert_eq!(user3_not_in_workspace.in_workspace, false);
+        assert!(user1_in_workspace.in_workspace);
+        assert!(user2_in_workspace.in_workspace);
+        assert!(!user3_not_in_workspace.in_workspace);
 
         //can read workspace
 
@@ -949,7 +946,7 @@ mod test {
             .delete_permission(new_permission.0.clone())
             .await
             .unwrap();
-        assert_eq!(is_deleted, true);
+        assert!(is_deleted);
         let workspace_owner = pool
             .get_workspace_owner(new_workspace.id.clone())
             .await
@@ -971,7 +968,7 @@ mod test {
             .delete_permission_by_query(new_user2.id.clone(), new_workspace.id.clone())
             .await
             .unwrap();
-        assert_eq!(is_deleted_by_query, true);
+        assert!(is_deleted_by_query);
         let workspace_owner = pool
             .get_workspace_owner(new_workspace.id.clone())
             .await
@@ -992,9 +989,9 @@ mod test {
             .get_user_in_workspace_by_email(new_workspace.id.clone(), &new_user3.email.clone())
             .await
             .unwrap();
-        assert_eq!(user1_in_workspace.in_workspace, true);
-        assert_eq!(user2_not_in_workspace.in_workspace, false);
-        assert_eq!(user3_not_in_workspace.in_workspace, false);
+        assert!(user1_in_workspace.in_workspace);
+        assert!(!user2_not_in_workspace.in_workspace);
+        assert!(!user3_not_in_workspace.in_workspace);
 
         //can read workspace after delete permission
 

--- a/libs/jwst-binding/jwst-jni/build.rs
+++ b/libs/jwst-binding/jwst-jni/build.rs
@@ -12,7 +12,6 @@ fn main() {
     let template = fs::read_to_string(in_src).unwrap();
     let template = template
         .split("use jni_sys::*;")
-        .into_iter()
         .collect::<Vec<_>>();
     let template = template
         .first()

--- a/libs/jwst-storage/src/storage/blobs.rs
+++ b/libs/jwst-storage/src/storage/blobs.rs
@@ -29,6 +29,7 @@ impl BlobAutoStorage {
         Self::init_with_pool(pool, get_bucket(is_sqlite)).await
     }
 
+    #[allow(unused)]
     async fn all(&self, table: &str) -> Result<Vec<BlobModel>, DbErr> {
         Blobs::find()
             .filter(BlobColumn::Workspace.eq(table))
@@ -36,6 +37,7 @@ impl BlobAutoStorage {
             .await
     }
 
+    #[allow(unused)]
     async fn count(&self, table: &str) -> Result<u64, DbErr> {
         Blobs::find()
             .filter(BlobColumn::Workspace.eq(table))

--- a/libs/jwst/src/block.rs
+++ b/libs/jwst/src/block.rs
@@ -632,7 +632,7 @@ mod test {
                 }
             );
         } else {
-            assert!(false)
+            unreachable!();
         }
     }
 }

--- a/libs/jwst/src/history/raw.rs
+++ b/libs/jwst/src/history/raw.rs
@@ -165,10 +165,10 @@ mod test {
             .transact()
             .encode_state_as_update_v1(&StateVector::default());
         let update = Update::decode_v1(&update).unwrap();
-        let mut items = update.as_items();
+        let items = update.as_items();
 
         let mut mock_histories: Vec<RawHistory> = vec![];
-        let parent_map = ParentMap::from(&mut items);
+        let parent_map = ParentMap::from(&items);
         for item in items {
             if let Some(parent) = parent_map.get(&item.id) {
                 let id = format!("{}:{}", item.id.clock, item.id.client);

--- a/libs/jwst/src/workspaces/workspace.rs
+++ b/libs/jwst/src/workspaces/workspace.rs
@@ -400,14 +400,14 @@ mod test {
                 Some("block".to_owned())
             );
 
-            assert_eq!(workspace.exists(&t.trx, "block"), true);
+            assert!(workspace.exists(&t.trx, "block"));
 
-            assert_eq!(t.remove("block"), true);
+            assert!(t.remove("block"));
 
             assert_eq!(workspace.blocks.len(&t.trx), 0);
             assert_eq!(workspace.updated.len(&t.trx), 0);
             assert_eq!(workspace.get(&t.trx, "block"), None);
-            assert_eq!(workspace.exists(&t.trx, "block"), false);
+            assert!(!workspace.exists(&t.trx, "block"));
         });
 
         workspace.with_trx(|mut t| {


### PR DESCRIPTION
- Apply clippy fix
- use mimalloc on `keck` and `cloud`
- `target-cpu=native` flag on Linux
- `opt-level = 3` instead of `z`, we can override this flag while building wasm
