### PR TITLE
feat: prevent collaboration of different sources, simplify workspace creation

### DIFF
--- a/apps/keck/src/server/sync/collaboration.rs
+++ b/apps/keck/src/server/sync/collaboration.rs
@@ -36,7 +36,7 @@ pub async fn upgrade_handler(
 
 #[cfg(test)]
 mod test {
-    use jwst_rpc::start_client;
+    use jwst_rpc::{get_workspace, start_sync_thread};
     use jwst::DocStorage;
     use jwst::{Block, Workspace};
     use jwst_logger::{error, info};
@@ -78,9 +78,10 @@ mod test {
                 entry.insert(tx);
             };
 
-            let workspace = start_client(&storage, workspace_id.clone(), remote)
-                .await
-                .unwrap();
+            let (workspace, rx) = get_workspace(&storage, workspace_id.clone()).await.unwrap();
+            if !remote.is_empty() {
+                start_sync_thread(&workspace, remote, rx);
+            }
 
             (workspace_id, workspace, storage)
         });
@@ -175,9 +176,10 @@ mod test {
                 entry.insert(tx);
             };
 
-            let workspace = start_client(&storage, workspace_id.clone(), remote)
-                .await
-                .unwrap();
+            let (workspace, rx) = get_workspace(&storage, workspace_id.clone()).await.unwrap();
+            if !remote.is_empty() {
+                start_sync_thread(&workspace, remote, rx);
+            }
 
             (workspace_id, workspace, storage)
         });

--- a/libs/jwst-binding/jwst-jni/src/storage.rs
+++ b/libs/jwst-binding/jwst-jni/src/storage.rs
@@ -2,7 +2,7 @@ use std::collections::hash_map::Entry;
 use crate::Workspace;
 use android_logger::Config;
 use jwst::{error, info, DocStorage, JwstError, JwstResult, LevelFilter};
-use jwst_rpc::start_client;
+use jwst_rpc::{get_workspace, start_sync_thread};
 use jwst_storage::JwstStorage as AutoStorage;
 use std::sync::Arc;
 use tokio::{runtime::Runtime, sync::RwLock};
@@ -55,14 +55,14 @@ impl JwstStorage {
         if let Some(storage) = &self.storage {
             let rt = Runtime::new().unwrap();
 
-            let mut workspace = rt.block_on(async move {
+            let (mut workspace, rx) = rt.block_on(async move {
                 let storage = storage.read().await;
-                if let Entry::Vacant(entry) = storage.docs().remote().write().await.entry(workspace_id.clone()) {
-                    let (tx, _rx) = channel(100);
-                    entry.insert(tx);
-                }
-                start_client(&storage, workspace_id, remote).await
-            })?;
+                get_workspace(&storage, workspace_id).await.unwrap()
+            });
+
+            if !remote.is_empty() {
+                start_sync_thread(&workspace, remote, rx);
+            }
 
             let (sub, workspace) = {
                 let id = workspace.id();

--- a/libs/jwst-binding/jwst-swift/src/storage.rs
+++ b/libs/jwst-binding/jwst-swift/src/storage.rs
@@ -1,7 +1,7 @@
 use std::collections::hash_map::Entry;
 use crate::Workspace;
 use jwst::{DocStorage, error, info, JwstError, JwstResult};
-use jwst_rpc::start_client;
+use jwst_rpc::{get_workspace, start_sync_thread};
 use jwst_storage::{JwstStorage as AutoStorage};
 use std::sync::Arc;
 use tokio::{runtime::Runtime, sync::RwLock};
@@ -48,14 +48,14 @@ impl Storage {
         if let Some(storage) = &self.storage {
             let rt = Runtime::new().unwrap();
 
-            let mut workspace = rt.block_on(async move {
+            let (mut workspace, rx) = rt.block_on(async move {
                 let storage = storage.read().await;
-                if let Entry::Vacant(entry) = storage.docs().remote().write().await.entry(workspace_id.clone()) {
-                    let (tx, _rx) = channel(100);
-                    entry.insert(tx);
-                }
-                start_client(&storage, workspace_id, remote).await
-            })?;
+                get_workspace(&storage, workspace_id).await.unwrap()
+            });
+
+            if !remote.is_empty() {
+                start_sync_thread(&workspace, remote, rx);
+            }
 
             let (sub, workspace) = {
                 let id = workspace.id();

--- a/libs/jwst-rpc/src/lib.rs
+++ b/libs/jwst-rpc/src/lib.rs
@@ -5,7 +5,7 @@ mod context;
 mod utils;
 
 pub use broadcast::{BroadcastChannels, BroadcastType};
-pub use client::{start_sync_thread, get_workspace};
+pub use client::{start_sync_thread, get_workspace, get_collaborating_worksapce};
 pub use connector::{memory_connector, socket_connector};
 pub use context::RpcContextImpl;
 pub use utils::{connect_memory_workspace, MinimumServerContext};

--- a/libs/jwst-rpc/src/lib.rs
+++ b/libs/jwst-rpc/src/lib.rs
@@ -5,7 +5,7 @@ mod context;
 mod utils;
 
 pub use broadcast::{BroadcastChannels, BroadcastType};
-pub use client::start_client;
+pub use client::{start_sync_thread, get_workspace};
 pub use connector::{memory_connector, socket_connector};
 pub use context::RpcContextImpl;
 pub use utils::{connect_memory_workspace, MinimumServerContext};

--- a/libs/jwst/src/workspaces/workspace.rs
+++ b/libs/jwst/src/workspaces/workspace.rs
@@ -11,15 +11,10 @@ use y_sync::{
     awareness::{Awareness, Event, Subscription as AwarenessSubscription},
     sync::{DefaultProtocol, Error, Message, MessageReader, Protocol, SyncMessage},
 };
-use yrs::{
-    types::{map::MapEvent, ToJson},
-    updates::{
-        decoder::{Decode, DecoderV1},
-        encoder::{Encode, Encoder, EncoderV1},
-    },
-    Doc, MapRef, Observable, ReadTxn, StateVector, Subscription, Transact, TransactionMut, Update,
-    UpdateEvent, UpdateSubscription,
-};
+use yrs::{types::{map::MapEvent, ToJson}, updates::{
+    decoder::{Decode, DecoderV1},
+    encoder::{Encode, Encoder, EncoderV1},
+}, Doc, MapRef, Observable, ReadTxn, StateVector, Subscription, Transact, TransactionMut, Update, UpdateEvent, UpdateSubscription, Map};
 
 static PROTOCOL: DefaultProtocol = DefaultProtocol;
 
@@ -82,6 +77,12 @@ impl Workspace {
             metadata,
             plugins,
         }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        let doc = self.doc();
+        let trx = doc.transact();
+        self.updated.len(&trx) == 0
     }
 
     /// Allow the plugin to run any necessary updates it could have flagged via observers.


### PR DESCRIPTION
1. separate logic of workspace creation and collaborating with remote, this helps reduce code nesting
from:
```rust
let rt = Runtime::new().unwrap();
rt.block_on(async {
    // some async task
    thread::spawn(|| {
        let rt = Runtime::new().unwrap();
        rt.block_on(async {
            // some async task
        })
    });
});
```
to:
```rust
let rt = Runtime::new().unwrap();
rt.block_on(async {
   // some async task
});
thread::spawn(|| {
    let rt = Runtime::new().unwrap();
    rt.block_on(async {
        // some async task
    })
});
```
2.  If a workspace is empty, prevent manipulating it before successfully collaborating with remote server. Otherwise it will cause the workspace having different source with workspace of remote server, in which cause future update cannot be merged.

close #309 
close #290 