### PR TITLE
feat: subscribing synchronized blocks from collaboration server

### DIFF
--- a/libs/jwst/src/space/mod.rs
+++ b/libs/jwst/src/space/mod.rs
@@ -128,7 +128,11 @@ impl Space {
         T: ReadTxn,
         S: AsRef<str>,
     {
-        Block::from(trx, self, block_id, self.client_id())
+        let mut block = Block::from(trx, self, block_id, self.client_id())?;
+        if let Some(block_observer_config) = self.block_observer_config.clone() {
+            block.subscribe(block_observer_config);
+        }
+        Some(block)
     }
 
     pub fn block_count(&self) -> u32 {

--- a/libs/jwst/src/workspace/block_observer.rs
+++ b/libs/jwst/src/workspace/block_observer.rs
@@ -11,6 +11,7 @@ use tokio::runtime::Runtime;
 use tokio::sync::RwLock;
 use tokio::time::sleep;
 use tracing::debug;
+use crate::Workspace;
 
 type CallbackFn = Arc<RwLock<Option<Box<dyn Fn(Vec<String>) + Send + Sync>>>>;
 pub struct BlockObserverConfig {
@@ -23,6 +24,7 @@ pub struct BlockObserverConfig {
     pub(super) modified_block_ids: Arc<RwLock<HashSet<String>>>,
     pub(crate) handle: Arc<Mutex<Option<JoinHandle<()>>>>,
     pub(crate) is_manually_tracking_block_changes: Arc<AtomicBool>,
+    pub(crate) observed_blocks: Arc<std::sync::RwLock<HashSet<String>>>,
 }
 
 impl BlockObserverConfig {
@@ -47,6 +49,7 @@ impl BlockObserverConfig {
             modified_block_ids,
             handle: Arc::new(Mutex::new(None)),
             is_manually_tracking_block_changes: Arc::default(),
+            observed_blocks: Arc::default(),
         };
 
         block_observer_config.handle = Arc::new(Mutex::new(Some(
@@ -126,5 +129,37 @@ impl BlockObserverConfig {
 impl Default for BlockObserverConfig {
     fn default() -> Self {
         BlockObserverConfig::new()
+    }
+}
+
+impl Workspace {
+    pub fn init_block_observer_config(&mut self) {
+        self.block_observer_config = Some(Arc::new(BlockObserverConfig::new()));
+        println!("init_block_observer_config self.block_observer_config.is_some(): {}", self.block_observer_config.is_some());
+    }
+
+    pub fn set_callback(&self, cb: Box<dyn Fn(Vec<String>) + Send + Sync>) -> bool {
+        if let Some(block_observer_config) = self.block_observer_config.clone() {
+            block_observer_config.set_callback(cb);
+            return true;
+        }
+        false
+    }
+
+    pub fn set_tracking_block_changes(&self, if_tracking: bool) {
+        if let Some(block_observer_config) = self.block_observer_config.clone() {
+            block_observer_config.set_tracking_block_changes(if_tracking);
+        }
+    }
+
+    pub fn retrieve_modified_blocks(&self) -> Option<HashSet<String>> {
+        self.block_observer_config
+            .clone()
+            .and_then(|block_observer_config| {
+                block_observer_config
+                    .is_manually_tracking_block_changes
+                    .load(Acquire)
+                    .then(|| block_observer_config.retrieve_modified_blocks())
+            })
     }
 }

--- a/libs/jwst/src/workspace/sync.rs
+++ b/libs/jwst/src/workspace/sync.rs
@@ -90,7 +90,6 @@ impl Workspace {
             }
         }
         if !content_msg.is_empty() {
-            self.try_subscribe_all_blocks();
             let doc = self.doc();
             if let Err(e) = catch_unwind(AssertUnwindSafe(|| {
                 let mut retry = 30;
@@ -153,6 +152,7 @@ impl Workspace {
             })) {
                 warn!("failed to apply update: {:?}", e);
             }
+            self.try_subscribe_all_blocks();
         }
 
         result

--- a/libs/jwst/src/workspace/sync.rs
+++ b/libs/jwst/src/workspace/sync.rs
@@ -158,8 +158,9 @@ impl Workspace {
         result
     }
 
-    fn try_subscribe_all_blocks(&mut self) {
+    pub fn try_subscribe_all_blocks(&mut self) {
         if let Some(block_observer_config) = self.block_observer_config.clone() {
+            // costing approximately 1ms per 500 blocks
             if let Err(e) = self.retry_with_trx(|mut t| {
                 t.get_blocks().blocks(&t.trx, |blocks| {
                     blocks.for_each(|mut block| {

--- a/libs/jwst/src/workspace/workspace.rs
+++ b/libs/jwst/src/workspace/workspace.rs
@@ -4,8 +4,6 @@ use super::{
 };
 use serde::{ser::SerializeMap, Serialize, Serializer};
 use std::{collections::HashMap, sync::Arc};
-use std::collections::HashSet;
-use std::sync::atomic::Ordering::Acquire;
 use std::sync::Mutex;
 use tokio::sync::RwLock;
 use y_sync::awareness::{Awareness, Event, Subscription as AwarenessSubscription};
@@ -100,31 +98,6 @@ impl Workspace {
 
     pub fn doc(&self) -> Doc {
         self.doc.clone()
-    }
-
-    pub fn set_callback(&self, cb: Box<dyn Fn(Vec<String>) + Send + Sync>) -> bool {
-        if let Some(block_observer_config) = self.block_observer_config.clone() {
-            block_observer_config.set_callback(cb);
-            return true;
-        }
-        false
-    }
-
-    pub fn set_tracking_block_changes(&self, if_tracking: bool) {
-        if let Some(block_observer_config) = self.block_observer_config.clone() {
-            block_observer_config.set_tracking_block_changes(if_tracking);
-        }
-    }
-
-    pub fn retrieve_modified_blocks(&self) -> Option<HashSet<String>> {
-        self.block_observer_config
-            .clone()
-            .and_then(|block_observer_config| {
-                block_observer_config
-                    .is_manually_tracking_block_changes
-                    .load(Acquire)
-                    .then(|| block_observer_config.retrieve_modified_blocks())
-            })
     }
 }
 

--- a/libs/jwst/src/workspace/workspace.rs
+++ b/libs/jwst/src/workspace/workspace.rs
@@ -46,7 +46,7 @@ impl Workspace {
         let updated = doc.get_or_insert_map("space:updated");
         let metadata = doc.get_or_insert_map("space:meta");
 
-        setup_plugin(Self {
+        let mut workspace = setup_plugin(Self {
             workspace_id: workspace_id.as_ref().to_string(),
             awareness: Arc::new(RwLock::new(Awareness::new(doc.clone()))),
             doc,
@@ -56,7 +56,9 @@ impl Workspace {
             metadata,
             plugins: Default::default(),
             block_observer_config: Some(Arc::new(BlockObserverConfig::new())),
-        })
+        });
+        workspace.try_subscribe_all_blocks();
+        workspace
     }
 
     fn from_raw<S: AsRef<str>>(
@@ -69,7 +71,7 @@ impl Workspace {
         metadata: MapRef,
         plugins: PluginMap,
     ) -> Workspace {
-        Self {
+        let mut workspace = Self {
             workspace_id: workspace_id.as_ref().to_string(),
             awareness,
             doc,
@@ -79,7 +81,9 @@ impl Workspace {
             metadata,
             plugins,
             block_observer_config: Some(Arc::new(BlockObserverConfig::new())),
-        }
+        };
+        workspace.try_subscribe_all_blocks();
+        workspace
     }
 
     pub fn is_empty(&self) -> bool {

--- a/libs/jwst/src/workspace/workspace.rs
+++ b/libs/jwst/src/workspace/workspace.rs
@@ -141,6 +141,7 @@ impl Clone for Workspace {
 
 #[cfg(test)]
 mod test {
+    use std::collections::HashSet;
     use super::{super::super::Block, *};
     use std::thread::sleep;
     use std::time::Duration;

--- a/libs/jwst/src/workspace/workspace.rs
+++ b/libs/jwst/src/workspace/workspace.rs
@@ -46,7 +46,7 @@ impl Workspace {
         let updated = doc.get_or_insert_map("space:updated");
         let metadata = doc.get_or_insert_map("space:meta");
 
-        let mut workspace = setup_plugin(Self {
+        setup_plugin(Self {
             workspace_id: workspace_id.as_ref().to_string(),
             awareness: Arc::new(RwLock::new(Awareness::new(doc.clone()))),
             doc,
@@ -56,9 +56,7 @@ impl Workspace {
             metadata,
             plugins: Default::default(),
             block_observer_config: Some(Arc::new(BlockObserverConfig::new())),
-        });
-        workspace.try_subscribe_all_blocks();
-        workspace
+        })
     }
 
     fn from_raw<S: AsRef<str>>(
@@ -71,7 +69,7 @@ impl Workspace {
         metadata: MapRef,
         plugins: PluginMap,
     ) -> Workspace {
-        let mut workspace = Self {
+        Self {
             workspace_id: workspace_id.as_ref().to_string(),
             awareness,
             doc,
@@ -81,9 +79,7 @@ impl Workspace {
             metadata,
             plugins,
             block_observer_config: Some(Arc::new(BlockObserverConfig::new())),
-        };
-        workspace.try_subscribe_all_blocks();
-        workspace
+        }
     }
 
     pub fn is_empty(&self) -> bool {


### PR DESCRIPTION
This PR adds:

1. subscribing `block` synchronized  from collaboration server
2. subscribing `block` when getting an already existing block from local storage
3. `is_consuming` interface for `BlockObserverConfig` to query whether the observed block id is being consumed

close #399 