### PR TITLE
feat: serialize block with detailed children info

### DIFF
--- a/libs/jwst/src/block/mod.rs
+++ b/libs/jwst/src/block/mod.rs
@@ -7,14 +7,10 @@ use serde_json::Value as JsonValue;
 use std::collections::HashMap;
 use std::fmt;
 use std::sync::{Arc, RwLock};
-use yrs::{
-    types::{
-        text::{Diff, YChange},
-        DeepEventsSubscription, ToJson, Value,
-    },
-    Array, ArrayPrelim, ArrayRef, DeepObservable, Doc, Map, MapPrelim, MapRef, ReadTxn, Text,
-    TextPrelim, TextRef, Transact, TransactionMut,
-};
+use yrs::{types::{
+    text::{Diff, YChange},
+    DeepEventsSubscription, ToJson, Value,
+}, Array, ArrayPrelim, ArrayRef, DeepObservable, Doc, Map, MapPrelim, MapRef, ReadTxn, Text, TextPrelim, TextRef, Transact, TransactionMut, Transaction};
 
 #[derive(Clone)]
 pub struct Block {
@@ -515,13 +511,13 @@ impl Serialize for Block {
     where
         S: Serializer,
     {
-        let trx = self.doc.transact_mut();
+        let trx = self.doc.transact();
         let value = serialize_block(self, &trx);
         value.serialize(serializer)
     }
 }
 
-fn serialize_block(block: &Block, trx: &TransactionMut) -> JsonValue {
+fn serialize_block(block: &Block, trx: &Transaction) -> JsonValue {
     let any = block.block.to_json(trx);
     let mut buffer = String::new();
     any.to_json(&mut buffer);

--- a/libs/jwst/src/block/mod.rs
+++ b/libs/jwst/src/block/mod.rs
@@ -13,7 +13,7 @@ use yrs::{
         DeepEventsSubscription, ToJson, Value,
     },
     Array, ArrayPrelim, ArrayRef, DeepObservable, Doc, Map, MapPrelim, MapRef, ReadTxn, Text,
-    TextPrelim, TextRef, Transact, Transaction, TransactionMut,
+    TextPrelim, TextRef, Transact, TransactionMut,
 };
 
 #[derive(Clone)]
@@ -516,7 +516,7 @@ impl Serialize for Block {
         S: Serializer,
     {
         let trx = self.doc.transact_mut();
-        let value = serialize_block(&self, &trx);
+        let value = serialize_block(self, &trx);
         value.serialize(serializer)
     }
 }
@@ -540,7 +540,6 @@ fn serialize_block(block: &Block, trx: &TransactionMut) -> JsonValue {
         .children
         .iter(trx)
         .map(|v| v.to_string(trx))
-        .into_iter()
         .for_each(|child_id| {
             children.push(serialize_block(&_space.get(trx, child_id).unwrap(), trx));
         });

--- a/libs/jwst/src/block/mod.rs
+++ b/libs/jwst/src/block/mod.rs
@@ -4,11 +4,9 @@ use super::{constants::sys, utils::JS_INT_RANGE, *};
 use lib0::any::Any;
 use serde::{Serialize, Serializer};
 use serde_json::Value::Object;
-use serde_json::{to_string, Value as JsonValue};
-use std::cell::{RefCell, RefMut};
+use serde_json::{Value as JsonValue};
 use std::collections::HashMap;
 use std::fmt;
-use std::rc::Rc;
 use std::sync::{Arc, RwLock};
 use yrs::{
     types::{

--- a/libs/jwst/src/block/mod.rs
+++ b/libs/jwst/src/block/mod.rs
@@ -542,7 +542,7 @@ fn serialize_children_to_map(
         .map(|v| v.to_string(trx))
         .for_each(|child_id| {
             if !target.contains_key(child_id.as_str()) {
-                let child = &space.get(trx, child_id.clone()).unwrap();
+                let child = &space.get(trx, child_id).unwrap();
                 let json_output = serialize_block(child, trx);
                 target.insert(child.block_id.clone(), Object(json_output));
                 serialize_children_to_map(child, trx, target, space);

--- a/libs/jwst/src/space/mod.rs
+++ b/libs/jwst/src/space/mod.rs
@@ -54,8 +54,8 @@ impl Space {
         }
     }
 
-    pub fn from_exists<I, S>(
-        trx: &TransactionMut,
+    pub fn from_exists<I, S, T>(
+        trx: &T,
         doc: Doc,
         workspace_id: I,
         space_id: S,
@@ -64,6 +64,7 @@ impl Space {
     where
         I: AsRef<str>,
         S: AsRef<str>,
+        T: ReadTxn,
     {
         let space_id = space_id.as_ref().into();
         let blocks = trx.get_map(&format!("space:{}", space_id))?;

--- a/libs/jwst/src/workspace/workspace.rs
+++ b/libs/jwst/src/workspace/workspace.rs
@@ -314,13 +314,13 @@ mod test {
             expected: serde_json::json!({
                 "space:space1": {
                     "block1": {
-                        "sys:children": [],
+                        "sys:children": {},
                         "sys:flavour": "text",
                     }
                 },
                 "space:space2": {
                     "block2": {
-                        "sys:children": [],
+                        "sys:children": {},
                         "sys:flavour": "text",
                     }
                 },


### PR DESCRIPTION
Given the block nesting level: 1 -> 2 -> 3

### Before
```json
{
    "sys:created": 946684800000.0,
    "sys:children": [
        "2"
    ],
    "sys:created": 1681961390341.0,
    "sys:flavour": "text",
    "sys:id": "1"
}
```

### After
```json
{
"sys:created": 946684800000.0,
"sys:children": {
  "2": {
    "sys:children": [
      "3"
    ],
    "sys:created": 1681961410014.0,
    "sys:flavour": "text",
    "sys:id": "2",
    "sys:parent": "1"
  },
  "3": {
    "sys:children": [],
    "sys:created": 1682323463794.0,
    "sys:flavour": "text",
    "sys:id": "3",
    "sys:parent": "2"
  }
},
"sys:created": 1681961390341.0,
"sys:flavour": "text",
"sys:id": "1"
}
```

### Deprecated

```json
{
  "sys:created": 946684800000.0,
  "sys:children": [
    {
      "sys:children": [
        {
          "sys:children": [],
          "sys:created": 1682323463794.0,
          "sys:flavour": "text",
          "sys:id": "3",
          "sys:parent": "2"
        }
      ],
      "sys:created": 1681961410014.0,
      "sys:flavour": "text",
      "sys:id": "2",
      "sys:parent": "1"
    }
  ],
  "sys:created": 1681961390341.0,
  "sys:flavour": "text",
  "sys:id": "1"
}
```