### PR TITLE
fix: block subscribing skipped caused by failing to update `observed_blocks`

### DIFF
--- a/libs/jwst-binding/jwst-jni/android/build.gradle
+++ b/libs/jwst-binding/jwst-jni/android/build.gradle
@@ -117,7 +117,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.toeverything'
             artifactId = 'octobase'
-            version = '0.1.17'
+            version = '0.1.18'
 
             afterEvaluate {
                 from components.release

--- a/libs/jwst/src/workspace/block_observer.rs
+++ b/libs/jwst/src/workspace/block_observer.rs
@@ -24,7 +24,6 @@ pub struct BlockObserverConfig {
     pub(super) modified_block_ids: Arc<RwLock<HashSet<String>>>,
     pub(crate) handle: Arc<Mutex<Option<JoinHandle<()>>>>,
     pub(crate) is_manually_tracking_block_changes: Arc<AtomicBool>,
-    pub(crate) observed_blocks: Arc<std::sync::RwLock<HashSet<String>>>,
     pub(crate) is_observing: Arc<AtomicBool>,
 }
 
@@ -50,7 +49,6 @@ impl BlockObserverConfig {
             modified_block_ids,
             handle: Arc::new(Mutex::new(None)),
             is_manually_tracking_block_changes: Arc::default(),
-            observed_blocks: Arc::default(),
             is_observing: Arc::default(),
         };
 

--- a/libs/jwst/src/workspace/workspace.rs
+++ b/libs/jwst/src/workspace/workspace.rs
@@ -216,7 +216,7 @@ mod test {
     #[test]
     fn block_observe_callback_triggered_by_get() {
         let workspace = Workspace::new("test");
-        workspace.set_callback(Box::new(|mut block_ids| {
+        workspace.set_callback(Box::new(|block_ids| {
             assert_eq!(block_ids, vec!["block1".to_string()]);
         }));
 


### PR DESCRIPTION
This PR:

Removed `observed_blocks`, now using `sub` to decide whether current `Block` has been subscribed. (As `observed_blocks` belongs to `Workspace`, for `Block` to update `observed_blocks` when it's dropped, we need to add a `Arc` reference to `observed_blocks`, which is verbose)