### PR TITLE
jwst codec refactory

### DIFF
--- a/libs/jwst-codec/src/doc/codec/item.rs
+++ b/libs/jwst-codec/src/doc/codec/item.rs
@@ -119,9 +119,9 @@ pub(crate) struct Item {
     pub origin_left_id: Option<Id>,
     pub origin_right_id: Option<Id>,
     #[cfg_attr(all(test, not(loom)), proptest(value = "None"))]
-    pub left: Option<StructInfo>,
+    pub left: Option<Node>,
     #[cfg_attr(all(test, not(loom)), proptest(value = "None"))]
-    pub right: Option<StructInfo>,
+    pub right: Option<Node>,
     pub parent: Option<Parent>,
     pub parent_sub: Option<String>,
     // make content Arc, so we can share the content between items
@@ -205,13 +205,13 @@ impl Item {
             id,
             origin_left_id: left.get().map(|left| left.last_id()),
             left: if left.is_some() {
-                Some(StructInfo::Item(left))
+                Some(Node::Item(left))
             } else {
                 None
             },
             origin_right_id: right.get().map(|right| right.id),
             right: if right.is_some() {
-                Some(StructInfo::Item(right))
+                Some(Node::Item(right))
             } else {
                 None
             },
@@ -268,14 +268,14 @@ impl Item {
                 continue;
             }
             match &n {
-                StructInfo::Item(item) => {
+                Node::Item(item) => {
                     ret.push(format!("{item}"));
                 }
-                StructInfo::GC { id, len } => {
+                Node::GC { id, len } => {
                     ret.push(format!("GC{id}: {len}"));
                     break;
                 }
-                StructInfo::Skip { id, len } => {
+                Node::Skip { id, len } => {
                     ret.push(format!("Skip{id}: {len}"));
                     break;
                 }
@@ -298,14 +298,14 @@ impl Item {
                 continue;
             }
             match &n {
-                StructInfo::Item(item) => {
+                Node::Item(item) => {
                     ret.push(format!("{item}"));
                 }
-                StructInfo::GC { id, len } => {
+                Node::GC { id, len } => {
                     ret.push(format!("GC{id}: {len}"));
                     break;
                 }
-                StructInfo::Skip { id, len } => {
+                Node::Skip { id, len } => {
                     ret.push(format!("Skip{id}: {len}"));
                     break;
                 }

--- a/libs/jwst-codec/src/doc/codec/item.rs
+++ b/libs/jwst-codec/src/doc/codec/item.rs
@@ -132,6 +132,9 @@ pub(crate) struct Item {
     pub flags: ItemFlags,
 }
 
+// make all Item readonly
+pub(crate) type ItemRef = Somr<Item>;
+
 impl PartialEq for Item {
     fn eq(&self, other: &Self) -> bool {
         self.id == other.id
@@ -166,9 +169,6 @@ impl std::fmt::Display for Item {
         write!(f, "Item{}: [{:?}]", self.id, self.content)
     }
 }
-
-// make all Item readonly
-pub(crate) type ItemRef = Somr<Item>;
 
 impl Default for Item {
     fn default() -> Self {
@@ -271,12 +271,12 @@ impl Item {
                 Node::Item(item) => {
                     ret.push(format!("{item}"));
                 }
-                Node::GC { id, len } => {
-                    ret.push(format!("GC{id}: {len}"));
+                Node::GC(item) => {
+                    ret.push(format!("GC{}: {}", item.id, item.len));
                     break;
                 }
-                Node::Skip { id, len } => {
-                    ret.push(format!("Skip{id}: {len}"));
+                Node::Skip(item) => {
+                    ret.push(format!("Skip{}: {}", item.id, item.len));
                     break;
                 }
             }
@@ -301,12 +301,12 @@ impl Item {
                 Node::Item(item) => {
                     ret.push(format!("{item}"));
                 }
-                Node::GC { id, len } => {
-                    ret.push(format!("GC{id}: {len}"));
+                Node::GC(item) => {
+                    ret.push(format!("GC{}: {}", item.id, item.len));
                     break;
                 }
-                Node::Skip { id, len } => {
-                    ret.push(format!("Skip{id}: {len}"));
+                Node::Skip(item) => {
+                    ret.push(format!("Skip{}: {}", item.id, item.len));
                     break;
                 }
             }

--- a/libs/jwst-codec/src/doc/codec/item.rs
+++ b/libs/jwst-codec/src/doc/codec/item.rs
@@ -230,14 +230,16 @@ impl Item {
         self.flags.deleted()
     }
 
-    pub fn delete(&self) {
+    pub fn delete(&self) -> bool {
         if self.deleted() {
-            return;
+            return false;
         }
 
         // self.content.delete();
 
         self.flags.set_deleted();
+
+        true
     }
 
     pub fn countable(&self) -> bool {

--- a/libs/jwst-codec/src/doc/codec/mod.rs
+++ b/libs/jwst-codec/src/doc/codec/mod.rs
@@ -16,6 +16,8 @@ pub use id::{Client, Clock, Id};
 pub use io::{CrdtRead, CrdtReader, CrdtWrite, CrdtWriter, RawDecoder, RawEncoder};
 pub(crate) use item::{Item, ItemFlags, ItemRef, Parent};
 pub(crate) use refs::Node;
+#[cfg(test)]
+pub(crate) use refs::NodeLen;
 pub use update::Update;
 #[cfg(test)]
 pub(crate) use utils::*;

--- a/libs/jwst-codec/src/doc/codec/mod.rs
+++ b/libs/jwst-codec/src/doc/codec/mod.rs
@@ -15,7 +15,7 @@ pub use delete_set::DeleteSet;
 pub use id::{Client, Clock, Id};
 pub use io::{CrdtRead, CrdtReader, CrdtWrite, CrdtWriter, RawDecoder, RawEncoder};
 pub(crate) use item::{Item, ItemFlags, ItemRef, Parent};
-pub(crate) use refs::StructInfo;
+pub(crate) use refs::Node;
 pub use update::Update;
 #[cfg(test)]
 pub(crate) use utils::*;

--- a/libs/jwst-codec/src/doc/codec/refs.rs
+++ b/libs/jwst-codec/src/doc/codec/refs.rs
@@ -212,12 +212,12 @@ impl StructInfo {
 
     #[inline]
     #[allow(dead_code)]
-    pub(crate) fn countable(&self) -> bool {
+    pub fn countable(&self) -> bool {
         self.flags().countable()
     }
 
     #[inline]
-    pub(crate) fn deleted(&self) -> bool {
+    pub fn deleted(&self) -> bool {
         self.flags().deleted()
     }
 }

--- a/libs/jwst-codec/src/doc/codec/refs.rs
+++ b/libs/jwst-codec/src/doc/codec/refs.rs
@@ -3,50 +3,50 @@ use super::*;
 // make fields Copy + Clone without much effort
 #[derive(Debug, Clone)]
 #[cfg_attr(all(test, not(loom)), derive(proptest_derive::Arbitrary))]
-pub(crate) enum StructInfo {
+pub(crate) enum Node {
     GC { id: Id, len: u64 },
     Skip { id: Id, len: u64 },
     Item(ItemRef),
 }
 
-impl<W: CrdtWriter> CrdtWrite<W> for StructInfo {
+impl<W: CrdtWriter> CrdtWrite<W> for Node {
     fn write(&self, writer: &mut W) -> JwstCodecResult {
         match self {
-            StructInfo::GC { len, .. } => {
+            Node::GC { len, .. } => {
                 writer.write_info(0)?;
                 writer.write_var_u64(*len)
             }
-            StructInfo::Skip { len, .. } => {
+            Node::Skip { len, .. } => {
                 writer.write_info(10)?;
                 writer.write_var_u64(*len)
             }
-            StructInfo::Item(item) => item.get().unwrap().write(writer),
+            Node::Item(item) => item.get().unwrap().write(writer),
         }
     }
 }
 
-impl PartialEq for StructInfo {
+impl PartialEq for Node {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
-            (StructInfo::GC { id: id1, .. }, StructInfo::GC { id: id2, .. }) => id1 == id2,
-            (StructInfo::Skip { id: id1, .. }, StructInfo::Skip { id: id2, .. }) => id1 == id2,
-            (StructInfo::Item(item1), StructInfo::Item(item2)) => item1.get() == item2.get(),
+            (Node::GC { id: id1, .. }, Node::GC { id: id2, .. }) => id1 == id2,
+            (Node::Skip { id: id1, .. }, Node::Skip { id: id2, .. }) => id1 == id2,
+            (Node::Item(item1), Node::Item(item2)) => item1.get() == item2.get(),
             _ => false,
         }
     }
 }
 
-impl Eq for StructInfo {
+impl Eq for Node {
     fn assert_receiver_is_total_eq(&self) {}
 }
 
-impl From<Item> for StructInfo {
+impl From<Item> for Node {
     fn from(value: Item) -> Self {
         Self::Item(Somr::new(value))
     }
 }
 
-impl StructInfo {
+impl Node {
     pub fn read<R: CrdtReader>(decoder: &mut R, id: Id) -> JwstCodecResult<Self> {
         let info = decoder.read_info()?;
         let first_5_bit = info & 0b11111;
@@ -54,11 +54,11 @@ impl StructInfo {
         match first_5_bit {
             0 => {
                 let len = decoder.read_var_u64()?;
-                Ok(StructInfo::GC { id, len })
+                Ok(Node::GC { id, len })
             }
             10 => {
                 let len = decoder.read_var_u64()?;
-                Ok(StructInfo::Skip { id, len })
+                Ok(Node::Skip { id, len })
             }
             _ => {
                 let item = Somr::new(Item::read(decoder, id, info, first_5_bit)?);
@@ -67,16 +67,16 @@ impl StructInfo {
                     ty.get().unwrap().write().unwrap().item = item.clone();
                 }
 
-                Ok(StructInfo::Item(item))
+                Ok(Node::Item(item))
             }
         }
     }
 
     pub fn id(&self) -> Id {
         match self {
-            StructInfo::GC { id, .. } => *id,
-            StructInfo::Skip { id, .. } => *id,
-            StructInfo::Item(item) => unsafe { item.get_unchecked() }.id,
+            Node::GC { id, .. } => *id,
+            Node::Skip { id, .. } => *id,
+            Node::Item(item) => unsafe { item.get_unchecked() }.id,
         }
     }
 
@@ -117,7 +117,7 @@ impl StructInfo {
     }
 
     pub fn left(&self) -> Option<Self> {
-        if let StructInfo::Item(item) = self {
+        if let Node::Item(item) = self {
             item.get().and_then(|item| item.left.clone())
         } else {
             None
@@ -125,7 +125,7 @@ impl StructInfo {
     }
 
     pub fn right(&self) -> Option<Self> {
-        if let StructInfo::Item(item) = self {
+        if let Node::Item(item) = self {
             item.get().and_then(|item| item.right.clone())
         } else {
             None
@@ -162,7 +162,7 @@ impl StructInfo {
     }
 
     pub fn flags(&self) -> ItemFlags {
-        if let StructInfo::Item(item) = self {
+        if let Node::Item(item) = self {
             item.get().unwrap().flags.clone()
         } else {
             // deleted
@@ -222,8 +222,8 @@ impl StructInfo {
     }
 }
 
-impl From<Option<StructInfo>> for Somr<Item> {
-    fn from(value: Option<StructInfo>) -> Self {
+impl From<Option<Node>> for Somr<Item> {
+    fn from(value: Option<Node>) -> Self {
         match value {
             Some(n) => n.as_item(),
             None => Somr::none(),
@@ -231,8 +231,8 @@ impl From<Option<StructInfo>> for Somr<Item> {
     }
 }
 
-impl From<&Option<StructInfo>> for Somr<Item> {
-    fn from(value: &Option<StructInfo>) -> Self {
+impl From<&Option<Node>> for Somr<Item> {
+    fn from(value: &Option<Node>) -> Self {
         match value {
             Some(n) => n.as_item(),
             None => Somr::none(),
@@ -240,8 +240,8 @@ impl From<&Option<StructInfo>> for Somr<Item> {
     }
 }
 
-impl From<Option<&StructInfo>> for Somr<Item> {
-    fn from(value: Option<&StructInfo>) -> Self {
+impl From<Option<&Node>> for Somr<Item> {
+    fn from(value: Option<&Node>) -> Self {
         match value {
             Some(n) => n.as_item(),
             None => Somr::none(),
@@ -258,7 +258,7 @@ mod tests {
     fn test_struct_info() {
         loom_model!({
             {
-                let struct_info = StructInfo::GC {
+                let struct_info = Node::GC {
                     id: Id::new(1, 0),
                     len: 10,
                 };
@@ -268,7 +268,7 @@ mod tests {
             }
 
             {
-                let struct_info = StructInfo::Skip {
+                let struct_info = Node::Skip {
                     id: Id::new(2, 0),
                     len: 20,
                 };
@@ -286,7 +286,7 @@ mod tests {
                     .parent_sub(None)
                     .content(Content::String(String::from("content")))
                     .build();
-                let struct_info = StructInfo::Item(Somr::new(item));
+                let struct_info = Node::Item(Somr::new(item));
 
                 assert_eq!(struct_info.len(), 7);
                 assert_eq!(struct_info.client(), 3);
@@ -298,7 +298,7 @@ mod tests {
     #[test]
     fn test_read_write_struct_info() {
         loom_model!({
-            let has_not_parent_id_and_has_parent = StructInfo::Item(Somr::new(
+            let has_not_parent_id_and_has_parent = Node::Item(Somr::new(
                 ItemBuilder::new()
                     .id((0, 0).into())
                     .left_id(None)
@@ -309,7 +309,7 @@ mod tests {
                     .build(),
             ));
 
-            let has_not_parent_id_and_has_parent_with_key = StructInfo::Item(Somr::new(
+            let has_not_parent_id_and_has_parent_with_key = Node::Item(Somr::new(
                 ItemBuilder::new()
                     .id((0, 0).into())
                     .left_id(None)
@@ -320,7 +320,7 @@ mod tests {
                     .build(),
             ));
 
-            let has_parent_id = StructInfo::Item(Somr::new(
+            let has_parent_id = Node::Item(Somr::new(
                 ItemBuilder::new()
                     .id((0, 0).into())
                     .left_id(Some((1, 2).into()))
@@ -332,11 +332,11 @@ mod tests {
             ));
 
             let struct_infos = vec![
-                StructInfo::GC {
+                Node::GC {
                     id: (0, 0).into(),
                     len: 42,
                 },
-                StructInfo::Skip {
+                Node::Skip {
                     id: (0, 0).into(),
                     len: 314,
                 },
@@ -350,15 +350,15 @@ mod tests {
                 info.write(&mut encoder).unwrap();
 
                 let mut decoder = RawDecoder::new(encoder.into_inner());
-                let decoded = StructInfo::read(&mut decoder, info.id()).unwrap();
+                let decoded = Node::read(&mut decoder, info.id()).unwrap();
 
                 assert_eq!(info, decoded);
             }
         });
     }
 
-    fn struct_info_round_trip(info: &mut StructInfo) -> JwstCodecResult {
-        if let StructInfo::Item(item) = info {
+    fn struct_info_round_trip(info: &mut Node) -> JwstCodecResult {
+        if let Node::Item(item) = info {
             if let Some(item) = item.get_mut() {
                 if !item.is_valid() {
                     return Ok(());
@@ -375,7 +375,7 @@ mod tests {
         let ret = encoder.into_inner();
         let mut decoder = RawDecoder::new(ret);
 
-        let decoded = StructInfo::read(&mut decoder, info.id())?;
+        let decoded = Node::read(&mut decoder, info.id())?;
 
         assert_eq!(info, &decoded);
 
@@ -386,7 +386,7 @@ mod tests {
     proptest! {
         #[test]
         #[cfg_attr(miri, ignore)]
-        fn test_random_struct_info(mut infos in vec(any::<StructInfo>(), 0..10)) {
+        fn test_random_struct_info(mut infos in vec(any::<Node>(), 0..10)) {
             for info in &mut infos {
                 struct_info_round_trip(info).unwrap();
             }

--- a/libs/jwst-codec/src/doc/codec/update.rs
+++ b/libs/jwst-codec/src/doc/codec/update.rs
@@ -492,10 +492,7 @@ mod tests {
                         VecDeque::from([
                             struct_item((0, 0), 1),
                             struct_item((0, 1), 1),
-                            Node::Skip {
-                                id: (0, 2).into(),
-                                len: 1,
-                            },
+                            Node::Skip(NodeLen::new((0, 2).into(), 1)),
                         ]),
                     ),
                     (

--- a/libs/jwst-codec/src/doc/codec/update.rs
+++ b/libs/jwst-codec/src/doc/codec/update.rs
@@ -5,12 +5,12 @@ use std::ops::Range;
 
 #[derive(Debug, Default)]
 pub struct Update {
-    pub(crate) structs: HashMap<u64, VecDeque<StructInfo>>,
+    pub(crate) structs: HashMap<u64, VecDeque<Node>>,
     pub(crate) delete_set: DeleteSet,
 
     /// all unapplicable items that we can't integrate into doc
     /// any item with inconsistent id clock or missing dependency will be put here
-    pub(crate) pending_structs: HashMap<Client, VecDeque<StructInfo>>,
+    pub(crate) pending_structs: HashMap<Client, VecDeque<Node>>,
     /// missing state vector after applying updates
     pub(crate) missing_state: StateVector,
     /// all unapplicable delete set
@@ -30,7 +30,7 @@ impl<R: CrdtReader> CrdtRead<R> for Update {
             let mut structs = VecDeque::with_capacity(num_of_structs as usize);
 
             for _ in 0..num_of_structs {
-                let struct_info = StructInfo::read(decoder, Id::new(client, clock))?;
+                let struct_info = Node::read(decoder, Id::new(client, clock))?;
                 clock += struct_info.len();
                 structs.push_back(struct_info);
             }
@@ -152,7 +152,7 @@ pub(crate) struct UpdateIterator<'a> {
     /// current id of client of the updates we're processing
     cur_client_id: Option<Client>,
     /// stack of previous iterating item with higher priority than updates in next iteration
-    stack: Vec<StructInfo>,
+    stack: Vec<Node>,
 }
 
 impl<'a> UpdateIterator<'a> {
@@ -217,7 +217,7 @@ impl<'a> UpdateIterator<'a> {
 
     /// tell if current update's dependencies(left, right, parent) has already been consumed and recorded
     /// and return the client of them if not.
-    fn get_missing_dep(&self, struct_info: &StructInfo) -> Option<Client> {
+    fn get_missing_dep(&self, struct_info: &Node) -> Option<Client> {
         if let Some(item) = struct_info.as_item().get() {
             let id = item.id;
             if let Some(left) = &item.origin_left_id {
@@ -248,7 +248,7 @@ impl<'a> UpdateIterator<'a> {
         None
     }
 
-    fn next_candidate(&mut self) -> Option<StructInfo> {
+    fn next_candidate(&mut self) -> Option<Node> {
         let mut cur = None;
 
         if !self.stack.is_empty() {
@@ -272,7 +272,7 @@ impl<'a> UpdateIterator<'a> {
 }
 
 impl Iterator for UpdateIterator<'_> {
-    type Item = (StructInfo, u64);
+    type Item = (Node, u64);
 
     fn next(&mut self) -> Option<Self::Item> {
         // fetch the first candidate from stack or updates
@@ -394,8 +394,8 @@ mod tests {
     use serde::Deserialize;
     use std::{num::ParseIntError, path::PathBuf};
 
-    fn struct_item(id: (Client, Clock), len: usize) -> StructInfo {
-        StructInfo::Item(Somr::new(
+    fn struct_item(id: (Client, Clock), len: usize) -> Node {
+        Node::Item(Somr::new(
             ItemBuilder::new()
                 .id(id.into())
                 .content(Content::String("c".repeat(len)))
@@ -492,7 +492,7 @@ mod tests {
                         VecDeque::from([
                             struct_item((0, 0), 1),
                             struct_item((0, 1), 1),
-                            StructInfo::Skip {
+                            Node::Skip {
                                 id: (0, 2).into(),
                                 len: 1,
                             },
@@ -502,7 +502,7 @@ mod tests {
                         1,
                         VecDeque::from([
                             struct_item((1, 0), 1),
-                            StructInfo::Item(Somr::new(
+                            Node::Item(Somr::new(
                                 ItemBuilder::new()
                                     .id((1, 1).into())
                                     .left_id(Some((0, 1).into()))

--- a/libs/jwst-codec/src/doc/codec/utils/items.rs
+++ b/libs/jwst-codec/src/doc/codec/utils/items.rs
@@ -19,14 +19,14 @@ impl ItemBuilder {
         self
     }
 
-    pub fn left(mut self, left: Option<StructInfo>) -> ItemBuilder {
+    pub fn left(mut self, left: Option<Node>) -> ItemBuilder {
         let origin_id = left.as_ref().map(|i| i.last_id());
         self.item.left = left;
         self.item.origin_left_id = origin_id;
         self
     }
 
-    pub fn right(mut self, right: Option<StructInfo>) -> ItemBuilder {
+    pub fn right(mut self, right: Option<Node>) -> ItemBuilder {
         let origin_id = right.as_ref().map(|i| i.id());
         self.item.right = right;
         self.item.origin_right_id = origin_id;

--- a/libs/jwst-codec/src/doc/document.rs
+++ b/libs/jwst-codec/src/doc/document.rs
@@ -90,7 +90,7 @@ impl Doc {
         let mut retry = false;
         loop {
             for (mut s, offset) in update.iter(store.get_state_vector()) {
-                if let StructInfo::Item(item) = &mut s {
+                if let Node::Item(item) = &mut s {
                     debug_assert!(item.is_owned());
                     let item = unsafe { item.get_mut_unchecked() };
                     store.repair(item, self.store.clone())?;

--- a/libs/jwst-codec/src/doc/store.rs
+++ b/libs/jwst-codec/src/doc/store.rs
@@ -536,13 +536,13 @@ impl DocStore {
                     parent_lock.take();
                 }
             }
-            Node::GC { id, len } => {
+            Node::GC(item) => {
                 if offset > 0 {
-                    id.clock += offset;
-                    *len -= offset;
+                    item.id.clock += offset;
+                    item.len -= offset;
                 }
             }
-            Node::Skip { .. } => {
+            Node::Skip(_) => {
                 // skip ignored
             }
         }
@@ -718,14 +718,8 @@ mod tests {
 
             let client_id = 1;
 
-            let struct_info1 = Node::GC {
-                id: Id::new(1, 1),
-                len: 5,
-            };
-            let struct_info2 = Node::Skip {
-                id: Id::new(1, 6),
-                len: 7,
-            };
+            let struct_info1 = Node::GC(NodeLen::new(Id::new(1, 1), 5));
+            let struct_info2 = Node::Skip(NodeLen::new(Id::new(1, 6), 7));
 
             doc_store
                 .items
@@ -751,20 +745,11 @@ mod tests {
             let mut doc_store = DocStore::with_client(1);
 
             let client1 = 1;
-            let struct_info1 = Node::GC {
-                id: (1, 0).into(),
-                len: 5,
-            };
+            let struct_info1 = Node::GC(NodeLen::new((1, 0).into(), 5));
 
             let client2 = 2;
-            let struct_info2 = Node::GC {
-                id: (2, 0).into(),
-                len: 6,
-            };
-            let struct_info3 = Node::Skip {
-                id: (2, 6).into(),
-                len: 1,
-            };
+            let struct_info2 = Node::GC(NodeLen::new((2, 0).into(), 6));
+            let struct_info3 = Node::Skip(NodeLen::new((2, 6).into(), 1));
 
             doc_store.items.insert(client1, vec![struct_info1.clone()]);
             doc_store
@@ -791,22 +776,10 @@ mod tests {
         loom_model!({
             let mut doc_store = DocStore::with_client(1);
 
-            let struct_info1 = Node::GC {
-                id: Id::new(1, 0),
-                len: 5,
-            };
-            let struct_info2 = Node::Skip {
-                id: Id::new(1, 5),
-                len: 1,
-            };
-            let struct_info3_err = Node::Skip {
-                id: Id::new(1, 5),
-                len: 1,
-            };
-            let struct_info3 = Node::Skip {
-                id: Id::new(1, 6),
-                len: 1,
-            };
+            let struct_info1 = Node::GC(NodeLen::new(Id::new(1, 0), 5));
+            let struct_info2 = Node::Skip(NodeLen::new(Id::new(1, 5), 1));
+            let struct_info3_err = Node::Skip(NodeLen::new(Id::new(1, 5), 1));
+            let struct_info3 = Node::Skip(NodeLen::new(Id::new(1, 6), 1));
 
             assert!(doc_store.add_item(struct_info1.clone()).is_ok());
             assert!(doc_store.add_item(struct_info2).is_ok());
@@ -829,10 +802,7 @@ mod tests {
     fn test_get_item() {
         loom_model!({
             let mut doc_store = DocStore::with_client(1);
-            let struct_info = Node::GC {
-                id: Id::new(1, 0),
-                len: 10,
-            };
+            let struct_info = Node::GC(NodeLen::new(Id::new(1, 0), 10));
             doc_store.add_item(struct_info.clone()).unwrap();
 
             assert_eq!(doc_store.get_node(Id::new(1, 9)), Some(struct_info));
@@ -840,14 +810,8 @@ mod tests {
 
         loom_model!({
             let mut doc_store = DocStore::with_client(1);
-            let struct_info1 = Node::GC {
-                id: Id::new(1, 0),
-                len: 10,
-            };
-            let struct_info2 = Node::GC {
-                id: Id::new(1, 10),
-                len: 20,
-            };
+            let struct_info1 = Node::GC(NodeLen::new(Id::new(1, 0), 10));
+            let struct_info2 = Node::GC(NodeLen::new(Id::new(1, 10), 20));
             doc_store.add_item(struct_info1).unwrap();
             doc_store.add_item(struct_info2.clone()).unwrap();
 
@@ -862,14 +826,8 @@ mod tests {
 
         loom_model!({
             let mut doc_store = DocStore::with_client(1);
-            let struct_info1 = Node::GC {
-                id: Id::new(1, 0),
-                len: 10,
-            };
-            let struct_info2 = Node::GC {
-                id: Id::new(1, 10),
-                len: 20,
-            };
+            let struct_info1 = Node::GC(NodeLen::new(Id::new(1, 0), 10));
+            let struct_info2 = Node::GC(NodeLen::new(Id::new(1, 10), 20));
             doc_store.add_item(struct_info1).unwrap();
             doc_store.add_item(struct_info2).unwrap();
 

--- a/libs/jwst-codec/src/doc/types/list/mod.rs
+++ b/libs/jwst-codec/src/doc/types/list/mod.rs
@@ -157,7 +157,7 @@ pub(crate) trait ListType: AsInner<Inner = YTypeRef> {
             None,
         );
 
-        store.integrate(StructInfo::Item(item), 0, Some(&mut lock))?;
+        store.integrate(Node::Item(item), 0, Some(&mut lock))?;
 
         Ok(())
     }

--- a/libs/jwst-codec/src/doc/types/list/mod.rs
+++ b/libs/jwst-codec/src/doc/types/list/mod.rs
@@ -210,19 +210,23 @@ pub(crate) trait ListType: AsInner<Inner = YTypeRef> {
         len: u64,
     ) -> JwstCodecResult {
         pos.normalize(store)?;
-        let mut remaining = len as i64;
+
+        let mut remaining = len;
 
         while remaining > 0 {
             if let Some(item) = pos.right.get() {
                 if !item.deleted() {
-                    let content_len = item.len() as i64;
+                    let content_len = item.len();
                     if remaining < content_len {
-                        store.split_node(item.id, remaining as u64)?;
+                        store.split_node(item.id, remaining)?;
                         remaining = 0;
                     } else {
                         remaining -= content_len;
                     }
-                    store.delete_item(item, Some(&mut lock));
+                    store
+                        .delete_set
+                        .add(item.id.client, item.id.clock, content_len);
+                    DocStore::delete_item(item, Some(&mut lock));
                 }
 
                 pos.forward();
@@ -232,7 +236,7 @@ pub(crate) trait ListType: AsInner<Inner = YTypeRef> {
         }
 
         if let Some(markers) = &lock.markers {
-            markers.update_marker_changes(pos.index, -(len as i64) + remaining);
+            markers.update_marker_changes(pos.index, -((len - remaining) as i64));
         }
 
         Ok(())

--- a/libs/jwst-codec/src/doc/types/list/mod.rs
+++ b/libs/jwst-codec/src/doc/types/list/mod.rs
@@ -8,9 +8,9 @@ use super::*;
 use crate::sync::RwLockWriteGuard;
 
 pub(crate) struct ItemPosition {
-    pub parent: Somr<RwLock<YType>>,
-    pub left: Somr<Item>,
-    pub right: Somr<Item>,
+    pub parent: YTypeRef,
+    pub left: ItemRef,
+    pub right: ItemRef,
     pub index: u64,
     pub offset: u64,
 }

--- a/libs/jwst-codec/src/doc/types/map.rs
+++ b/libs/jwst-codec/src/doc/types/map.rs
@@ -65,11 +65,9 @@ pub(crate) trait MapType: AsInner<Inner = YTypeRef> {
 
     fn remove(&mut self, key: impl AsRef<str>) {
         let mut inner = self.as_inner().get().unwrap().write().unwrap();
-        if let Some(store) = inner.store_mut() {
-            let node = inner.map.as_ref().and_then(|map| map.get(key.as_ref()));
-            if let Some(item) = ItemRef::from(node).get() {
-                store.delete_item(item, Some(&mut inner));
-            }
+        let node = inner.map.as_ref().and_then(|map| map.get(key.as_ref()));
+        if let Some(item) = ItemRef::from(node).get() {
+            DocStore::delete_item(item, Some(&mut inner));
         }
     }
 

--- a/libs/jwst-codec/src/doc/types/map.rs
+++ b/libs/jwst-codec/src/doc/types/map.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::sync::Arc;
 use crate::{
-    doc::{AsInner, Parent, StructInfo, YTypeRef},
+    doc::{AsInner, Node, Parent, YTypeRef},
     impl_type, Content, JwstCodecResult,
 };
 use std::collections::HashMap;
@@ -25,7 +25,7 @@ pub(crate) trait MapType: AsInner<Inner = YTypeRef> {
                 Some(Parent::Type(self.as_inner().clone())),
                 Some(key.as_ref().into()),
             );
-            store.integrate(StructInfo::Item(item), 0, Some(&mut inner))?;
+            store.integrate(Node::Item(item), 0, Some(&mut inner))?;
         }
 
         Ok(())

--- a/libs/jwst-codec/src/doc/types/mod.rs
+++ b/libs/jwst-codec/src/doc/types/mod.rs
@@ -135,8 +135,7 @@ impl YTypeBuilder {
     pub fn build<T: TryFrom<YTypeRef, Error = JwstCodecError>>(self) -> JwstCodecResult<T> {
         let mut store = self.store.write().unwrap();
         let ty = if let Some(root_name) = self.root_name {
-            let mut types = store.types.write().unwrap();
-            match types.entry(root_name.clone()) {
+            match store.types.entry(root_name.clone()) {
                 Entry::Occupied(e) => e.get().clone(),
                 Entry::Vacant(e) => {
                     let ty = Somr::new(RwLock::new(YType {

--- a/libs/jwst-codec/src/doc/types/mod.rs
+++ b/libs/jwst-codec/src/doc/types/mod.rs
@@ -16,7 +16,7 @@ use crate::{Item, JwstCodecError, JwstCodecResult};
 
 use super::{
     store::{StoreRef, WeakStoreRef},
-    StructInfo,
+    Node,
 };
 
 #[derive(Debug, Default)]
@@ -24,7 +24,7 @@ pub(crate) struct YType {
     pub store: WeakStoreRef,
     pub start: Somr<Item>,
     pub item: Somr<Item>,
-    pub map: Option<HashMap<String, StructInfo>>,
+    pub map: Option<HashMap<String, Node>>,
     pub len: u64,
     /// The tag name of XMLElement and XMLHook type
     pub name: Option<String>,


### PR DESCRIPTION
- [x] remove useless RWLock in DocStore, because we always hold the R/W lock of DocStore itself before we accessing it
- [x] rename StructInfo to Node
- [x] Make Node struct thiner then before(4 bytes => 2 bytes)